### PR TITLE
Add is already subscribed function isAlreadySubscribed

### DIFF
--- a/app/code/community/Turiknox/CheckoutNewsletter/Block/Newsletter.php
+++ b/app/code/community/Turiknox/CheckoutNewsletter/Block/Newsletter.php
@@ -38,4 +38,23 @@ class Turiknox_CheckoutNewsletter_Block_Newsletter extends Mage_Core_Block_Templ
     {
         return $this->escapeHtml(Mage::getStoreConfig('newsletter/checkout/text'));
     }
+
+     /**
+     * Check if email address already known in checkout and if yes then validate against subscription to show/hide the option
+     *
+     * @return boolean
+     */
+    public function isAlreadySubscribed()
+    {
+    $IsSubscribed = false;
+    $customer = Mage::getSingleton('customer/session')->getCustomer();
+    if ($customer) {
+        $customerEmail = $customer->getEmail();
+        $subscriber = Mage::getModel('newsletter/subscriber')->loadByEmail($customerEmail);
+        if ($subscriber) {
+            $IsSubscribed = $subscriber->isSubscribed();
+        }
+    }
+    return $IsSubscribed;
+    }
 }


### PR DESCRIPTION
Add is already subscribed function isAlreadySubscribed

Will only work ofcourse if the information has already been submitted. But is usefull especially if the checkbox is being shown on other pages when we DO know the email address

Solves part of #4 where it is not logical to show the subscription (and unsubscribe) option to customers who are already subscribed